### PR TITLE
don't loop until t is greater than 1

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Core/Runtime/Objects/VertexPath.cs
+++ b/Path Creator Project/Assets/PathCreator/Core/Runtime/Objects/VertexPath.cs
@@ -268,7 +268,9 @@ namespace PathCreation {
                     if (t < 0) {
                         t += Mathf.CeilToInt (Mathf.Abs (t));
                     }
-                    t %= 1;
+                    if(t > 1) {
+                        t %= 1;   
+                    }
                     break;
                 case EndOfPathInstruction.Reverse:
                     t = Mathf.PingPong (t, 1);


### PR DESCRIPTION
proposed fix for issue where GetPointAtTime(t) returns the start position rather than the end position of the path when t == 1
https://github.com/SebLague/Path-Creator/issues/100