### PR TITLE
Add path generation button to GeneratePathExample

### DIFF
--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/Editor/GeneratePathExampleEditor.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/Editor/GeneratePathExampleEditor.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEditor;
+using PathCreation;
+
+namespace PathCreation.Examples
+{
+    [CustomEditor(typeof(GeneratePathExample), true)]
+    public class GeneratePathExampleEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            GeneratePathExample generatePathExample = (GeneratePathExample) target;
+            if (GUILayout.Button("Generate Path"))
+            {
+                generatePathExample.GeneratePath();
+            }
+        }
+    }   
+}

--- a/Path Creator Project/Assets/PathCreator/Examples/Scripts/GeneratePathExample.cs
+++ b/Path Creator Project/Assets/PathCreator/Examples/Scripts/GeneratePathExample.cs
@@ -1,19 +1,20 @@
 ﻿using UnityEngine;
 
 namespace PathCreation.Examples {
-    // Example of creating a path at runtime from a set of points.
-
+    // Example of creating a path from a set of points upon button press in the editor.
     [RequireComponent(typeof(PathCreator))]
-    public class GeneratePathExample : MonoBehaviour {
-
+    public class GeneratePathExample : MonoBehaviour
+    {
         public bool closedLoop = true;
-        public Transform[] waypoints;
+        public Transform[] waypoints = new Transform[0];
 
-        void Start () {
-            if (waypoints.Length > 0) {
+        public void GeneratePath()
+        {
+            if (waypoints.Length > 0)
+            {
                 // Create a new bezier path from the waypoints.
-                BezierPath bezierPath = new BezierPath (waypoints, closedLoop, PathSpace.xyz);
-                GetComponent<PathCreator> ().bezierPath = bezierPath;
+                BezierPath bezierPath = new BezierPath(waypoints, closedLoop, PathSpace.xyz);
+                GetComponent<PathCreator>().bezierPath = bezierPath;
             }
         }
     }


### PR DESCRIPTION
Now PathCreator variables are not reset on runtime when using GeneratePathExample.